### PR TITLE
[Bugfix/52] 배치에 따른 백업 버그수정

### DIFF
--- a/src/main/java/com/ohgiraffers/hrbank/repository/BackupRepository.java
+++ b/src/main/java/com/ohgiraffers/hrbank/repository/BackupRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface BackupRepository extends JpaRepository<Backup, Long> {
 
-    List<Backup> findAllByWorker(String worker);
+    List<Backup> findAll();
 
     @Query("""
         SELECT d FROM Backup d

--- a/src/main/java/com/ohgiraffers/hrbank/repository/BackupRepository.java
+++ b/src/main/java/com/ohgiraffers/hrbank/repository/BackupRepository.java
@@ -4,6 +4,7 @@ import com.ohgiraffers.hrbank.entity.Backup;
 import com.ohgiraffers.hrbank.entity.StatusType;
 import java.time.Instant;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -23,7 +24,7 @@ public interface BackupRepository extends JpaRepository<Backup, Long> {
               OR (d.startedAt = CAST(:cursor AS java.time.Instant) AND d.id <= :idAfter)
           )
     """)
-    List<Backup> findAllWithCursor(
+    Page<Backup> findAllWithCursor(
         @Param("worker") String worker,
         @Param("status") StatusType status,
         @Param("startedAtFrom") Instant startedAtFrom,
@@ -41,7 +42,7 @@ public interface BackupRepository extends JpaRepository<Backup, Long> {
       AND (CAST(:startedAtFrom AS java.time.Instant) IS NULL OR d.startedAt >= :startedAtFrom)
       AND (CAST(:startedAtTo AS java.time.Instant) IS NULL OR d.startedAt <= :startedAtTo)
 """)
-    List<Backup> findAllWithoutCursor(
+    Page<Backup> findAllWithoutCursor(
         @Param("worker") String worker,
         @Param("status") StatusType status,
         @Param("startedAtFrom") Instant startedAtFrom,

--- a/src/main/java/com/ohgiraffers/hrbank/service/basic/BasicBackupService.java
+++ b/src/main/java/com/ohgiraffers/hrbank/service/basic/BasicBackupService.java
@@ -127,8 +127,10 @@ public class BasicBackupService implements BackupService {
         // 6. totalElements 찾기
         Long totalElements = backupRepository.count();
 
-        // 7. 마지막 행 제거
-        content.remove(content.size() - 1);
+        // 7. 마지막 페이지가 아닐경우 해당 페이지의 마지막 행 제거
+        if (hasNext) {
+            content.remove(content.size() - 1);
+        }
 
         return new CursorPageResponseBackupDto(content,nextCursor,nextIdAfter,size,totalElements,hasNext);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #52 

## 📝작업 내용

데이터 백업 조회시 가장 마지막 Element가 조회되지 않는 버그
데이터 백업 조회시 조건 설정했을때 totalElements가 정상적으로 출력되지 않는버그 (조건에 부합하는 갯수 출력해야함)
백업파일이 정상적으로 다운로드 되지 않는 버그
데이터 백업 조회시 조건 설정했을때 조건에 맞는 내용이 없으면 500에러 발생하는 버그
데이터 백업 조회시 가장 마지막 페이지에서 nextCursor와 nextIdAfter가 null이 되지않는버그
데이터 백업 생성시 한번 백업 생성한 이후에 백업 생성 눌러도 건너뜀이 아닌 백업이 생성되는 버그
디버깅완료

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/058a1ebc-d3ec-4adf-939b-d1d535f7e5f7)

## ✅PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인해주세요

<!-- Commit message convention 참고  (Ctrl + 클릭하세요) -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 변경 사항에 대한 테스트를 했습니다 (버그 수정/기능에 대한 테스트)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?