### PR TITLE
[Feature/departments] fix: 부서 설립일 기준 정렬시 다음 페이지 에러 Fix

### DIFF
--- a/src/main/java/com/ohgiraffers/hrbank/repository/DepartmentRepository.java
+++ b/src/main/java/com/ohgiraffers/hrbank/repository/DepartmentRepository.java
@@ -62,8 +62,7 @@ public interface DepartmentRepository extends JpaRepository<Department, Integer>
     WHERE
         (:nameOrDescription IS NULL OR d.name LIKE %:nameOrDescription% OR d.description LIKE %:nameOrDescription%)
         AND (
-            (:Cursor IS NULL)
-            OR (d.establishedDate > :Cursor)
+            d.establishedDate > :Cursor
             OR (d.establishedDate = :Cursor AND d.id > :IdAfter)
         )
     ORDER BY d.establishedDate ASC, d.id ASC
@@ -81,8 +80,7 @@ public interface DepartmentRepository extends JpaRepository<Department, Integer>
     WHERE
         (:nameOrDescription IS NULL OR d.name LIKE %:nameOrDescription% OR d.description LIKE %:nameOrDescription%)
         AND (
-            (:Cursor IS NULL)
-            OR (d.establishedDate < :Cursor)
+            (d.establishedDate < :Cursor)
             OR (d.establishedDate = :Cursor AND d.id < :IdAfter)
         )
     ORDER BY d.establishedDate DESC, d.id DESC
@@ -93,7 +91,17 @@ public interface DepartmentRepository extends JpaRepository<Department, Integer>
         @Param("IdAfter") Long idAfter,
         Pageable pageable
     );
-
+    // 커서가 없을 때는 모든 데이터를 가져옴
+    @Query("""
+SELECT d FROM Department d
+WHERE
+    (:nameOrDescription IS NULL OR d.name LIKE %:nameOrDescription% OR d.description LIKE %:nameOrDescription%)
+ORDER BY d.establishedDate ASC, d.id ASC
+""")
+    List<Department> findByCursorDateAscWithoutCursor(
+        @Param("nameOrDescription") String nameOrDescription,
+        Pageable pageable
+    );
     // name이나 description에 검색어가 포함된 개수 반환
     @Query("SELECT COUNT(d) FROM Department d WHERE d.name LIKE %:keyword% OR d.description LIKE %:keyword%")
     long countByNameOrDescription(@Param("keyword") String keyword);

--- a/src/main/java/com/ohgiraffers/hrbank/service/basic/BasicDepartmentService.java
+++ b/src/main/java/com/ohgiraffers/hrbank/service/basic/BasicDepartmentService.java
@@ -151,8 +151,14 @@ public class BasicDepartmentService implements DepartmentService {
                 );
             }
         } else if ("establishedDate".equals(sortField)) {
-            LocalDate cursorDate = (cursor == null) ? null : LocalDate.parse(cursor);
-            if ("asc".equalsIgnoreCase(sortDirection)) {
+            LocalDate cursorDate = (cursor == null || cursor.isBlank()) ? null : LocalDate.parse(cursor); // cursor를 String에서 LocalDate로 파싱
+            System.out.println("cursor 값: " + cursor + ", cursorDate: " + cursorDate + ", 타입: " + (cursorDate != null ? cursorDate.getClass() : null));
+            if(cursorDate == null){
+                departments = departmentRepository.findByCursorDateAscWithoutCursor(
+                    keyword.isEmpty() ? null : keyword,
+                    pageable
+                );
+            } else if ("asc".equalsIgnoreCase(sortDirection)) {
                 departments = departmentRepository.findByCursorDateAsc(
                     keyword.isEmpty() ? null : keyword,
                     cursorDate,


### PR DESCRIPTION
## #️⃣연관된 이슈

#12 

## 📝작업 내용

> 첫 페이지에서 cursor값을 null로 입력하는 경우 LocalDate값으로 null을 입력하여 타입불일치 문제 발견.
> null 입력시 쿼리에 넘기지 않는 로직으로 수정.

## ✅PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 변경 사항에 대한 테스트를 했습니다 (버그 수정/기능에 대한 테스트)